### PR TITLE
Update altCMakeLists.cmake

### DIFF
--- a/altCMakeLists.cmake
+++ b/altCMakeLists.cmake
@@ -3,10 +3,6 @@
 cmake_minimum_required(VERSION 3.3.0)
 project(canvas VERSION 1.4.2)
 
-# CMAKE_MODULE_PATH not picked up from the environemnt?
-list(INSERT CMAKE_MODULE_PATH 0 $ENV{CMAKE_MODULE_PATH})
-
-
 # - Cetbuildtools, version2
 find_package(cetbuildtools2 0.1.0 REQUIRED)
 list(INSERT CMAKE_MODULE_PATH 0 ${cetbuildtools2_MODULE_PATH})


### PR DESCRIPTION
This line can be dropped. I think I picked up the pattern from Brett. He had to do this for the worch build. It causes a problem with the spack build because that environment variable is not defined.
